### PR TITLE
fix: Lede text set to white

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-20 lg:py-24 relative z-10">
             <div class="text-center text-white">
                 {% if home_content %}
-                    <p class="text-xl sm:text-2xl md:text-3xl lg:text-4xl mb-6 sm:mb-8 max-w-3xl mx-auto px-4 sm:px-0 text-white">
+                    <p class="text-xl sm:text-2xl md:text-3xl lg:text-4xl mb-6 sm:mb-8 max-w-3xl mx-auto px-4 sm:px-0" style="color: white !important;">
                         {{ home_content.lede|safe }}
                     </p>
                 {% else %}


### PR DESCRIPTION
This pull request makes a minor adjustment to the styling of the home page content in `templates/index.html`. Specifically, it ensures that the text color of the main lede paragraph is always white by adding an inline style, which overrides any conflicting styles that may have been applied elsewhere.