### PR TITLE
Feat: nested child pages in navigation

### DIFF
--- a/content/context_processors.py
+++ b/content/context_processors.py
@@ -1,29 +1,33 @@
 from wagtail.models import Page
 
 
+def _build_nav_tree(page, max_depth=3):
+    """
+    Recursively build navigation data for a page and its children.
+    max_depth limits how many levels deep to traverse (1 = just this level's children).
+    """
+    children_pages = page.get_children().live().in_menu()
+    children = []
+    if max_depth > 0:
+        for child in children_pages:
+            children.append(_build_nav_tree(child, max_depth - 1))
+    return {
+        "page": page,
+        "children": children,
+        "has_children": len(children) > 0,
+    }
+
+
 def navigation(request):
     """
     Add navigation menu items to template context from Wagtail pages.
-    Includes child pages for dropdown functionality.
+    Supports nested child pages up to 3 levels deep.
     """
     try:
-        # Get the root page (usually the home page)
         root_page = Page.objects.filter(depth=2).first()
         if root_page:
-            # Get all live pages that are direct children of root
             nav_pages = root_page.get_children().live().in_menu()
-
-            # Build navigation data with child pages
-            nav_data = []
-            for page in nav_pages:
-                children = page.get_children().live().in_menu()
-                nav_data.append(
-                    {
-                        "page": page,
-                        "children": children,
-                        "has_children": children.exists(),
-                    }
-                )
+            nav_data = [_build_nav_tree(page, max_depth=2) for page in nav_pages]
         else:
             nav_data = []
     except Exception:

--- a/templates/base.html
+++ b/templates/base.html
@@ -102,7 +102,23 @@
                                     </button>
                                     <ul class="dropdown-menu absolute left-0 top-full w-48 py-2 z-50 hidden border-l border-r border-b border-gray-200 list-none m-0 p-0" style="background-color: #ffffff;">
                                         {% for child in nav_item.children %}
-                                            <li><a href="{{ child.url }}" class="block px-4 py-3 text-base text-gray-700 hover:bg-gray-50 hover:text-gray-900 transition-colors duration-150">{{ child.title }}</a></li>
+                                            <li class="{% if child.has_children %}relative submenu-parent{% endif %}">
+                                                <a href="{{ child.page.url }}" class="block px-4 py-3 text-base text-gray-700 hover:bg-gray-50 hover:text-gray-900 transition-colors duration-150 {% if child.has_children %}flex items-center justify-between{% endif %}">
+                                                    {{ child.page.title }}
+                                                    {% if child.has_children %}
+                                                        <svg class="w-3 h-3 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                                                        </svg>
+                                                    {% endif %}
+                                                </a>
+                                                {% if child.has_children %}
+                                                    <ul class="submenu absolute left-full top-0 w-48 py-2 hidden border border-gray-200 list-none m-0 p-0" style="background-color: #ffffff;">
+                                                        {% for grandchild in child.children %}
+                                                            <li><a href="{{ grandchild.page.url }}" class="block px-4 py-3 text-base text-gray-700 hover:bg-gray-50 hover:text-gray-900 transition-colors duration-150">{{ grandchild.page.title }}</a></li>
+                                                        {% endfor %}
+                                                    </ul>
+                                                {% endif %}
+                                            </li>
                                         {% endfor %}
                                     </ul>
                                 </li>
@@ -139,12 +155,34 @@
                 </div>
                 <!-- Mobile Navigation Menu -->
                 <div id="mobile-menu" class="md:hidden hidden">
-                    <ul class="px-4 pt-4 pb-6 space-y-3 bg-white border-t border-gray-200 list-none m-0 p-0">
-                        {% for page in nav_pages %}
+                    <ul class="px-4 pt-4 pb-6 space-y-1 bg-white border-t border-gray-200 list-none m-0 p-0">
+                        {% for nav_item in nav_data %}
                             <li>
-                                <a href="{{ page.url }}" class="mobile-link text-gray-700 hover:text-gray-900 block px-3 py-3 text-lg font-medium border-l-4 border-transparent hover:border-gray-400 transition-all duration-200 {% if request.resolver_match.url_name == page.slug %}text-gray-900 border-gray-400{% endif %}">
-                                    {{ page.title }}
+                                <a href="{{ nav_item.page.url }}" class="mobile-link text-gray-700 hover:text-gray-900 block px-3 py-3 text-lg font-medium border-l-4 border-transparent hover:border-gray-400 transition-all duration-200">
+                                    {{ nav_item.page.title }}
                                 </a>
+                                {% if nav_item.has_children %}
+                                    <ul class="list-none m-0 p-0 pl-4">
+                                        {% for child in nav_item.children %}
+                                            <li>
+                                                <a href="{{ child.page.url }}" class="mobile-link text-gray-600 hover:text-gray-900 block px-3 py-2 text-base font-medium border-l-4 border-transparent hover:border-gray-400 transition-all duration-200">
+                                                    {{ child.page.title }}
+                                                </a>
+                                                {% if child.has_children %}
+                                                    <ul class="list-none m-0 p-0 pl-4">
+                                                        {% for grandchild in child.children %}
+                                                            <li>
+                                                                <a href="{{ grandchild.page.url }}" class="mobile-link text-gray-500 hover:text-gray-900 block px-3 py-2 text-sm font-medium border-l-4 border-transparent hover:border-gray-400 transition-all duration-200">
+                                                                    {{ grandchild.page.title }}
+                                                                </a>
+                                                            </li>
+                                                        {% endfor %}
+                                                    </ul>
+                                                {% endif %}
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
+                                {% endif %}
                             </li>
                         {% endfor %}
                         <li>
@@ -221,9 +259,20 @@
                                     <ul class="space-y-2 list-none m-0 p-0">
                                         {% for child in nav_item.children %}
                                             <li>
-                                                <a href="{{ child.url }}" class="text-gray-300 hover:text-white transition-colors duration-200 text-base">
-                                                    {{ child.title }}
+                                                <a href="{{ child.page.url }}" class="text-gray-300 hover:text-white transition-colors duration-200 text-base">
+                                                    {{ child.page.title }}
                                                 </a>
+                                                {% if child.has_children %}
+                                                    <ul class="space-y-1 list-none m-0 p-0 pl-3 mt-1">
+                                                        {% for grandchild in child.children %}
+                                                            <li>
+                                                                <a href="{{ grandchild.page.url }}" class="text-gray-400 hover:text-white transition-colors duration-200 text-sm">
+                                                                    {{ grandchild.page.title }}
+                                                                </a>
+                                                            </li>
+                                                        {% endfor %}
+                                                    </ul>
+                                                {% endif %}
                                             </li>
                                         {% endfor %}
                                     </ul>
@@ -289,6 +338,24 @@
                 dropdown.addEventListener('mouseleave', function() {
                     timeout = setTimeout(function() {
                         menu.classList.add('hidden');
+                    }, 150);
+                });
+            });
+
+            // Desktop submenu flyouts (hover with delay)
+            document.querySelectorAll('.submenu-parent').forEach(function(parent) {
+                const submenu = parent.querySelector('.submenu');
+                if (!submenu) return;
+                let subTimeout;
+
+                parent.addEventListener('mouseenter', function() {
+                    clearTimeout(subTimeout);
+                    submenu.classList.remove('hidden');
+                });
+
+                parent.addEventListener('mouseleave', function() {
+                    subTimeout = setTimeout(function() {
+                        submenu.classList.add('hidden');
                     }, 150);
                 });
             });


### PR DESCRIPTION
## Summary
- Refactor nav context processor to recursively build Wagtail page tree up to 3 levels deep (resolves #56)
- Desktop nav: child pages with sub-children show a right-arrow indicator and flyout submenu on hover
- Mobile nav: nested children render as indented lists with decreasing text size per level
- Footer nav: also renders the full page tree with nested indentation
- All three stay in sync automatically as Wagtail pages are added/removed via CMS
