### PR TITLE
fix: Handle None type in PersonRelation.__str__

### DIFF
--- a/mapping_violence/models.py
+++ b/mapping_violence/models.py
@@ -570,9 +570,12 @@ class PersonRelation(models.Model):
         ]
 
     def __str__(self):
-        relation_type = (
-            f"{self.type}-{self.type.converse_name}"
-            if self.type.converse_name
-            else self.type
-        )
+        if self.type:
+            relation_type = (
+                f"{self.type}-{self.type.converse_name}"
+                if self.type.converse_name
+                else self.type
+            )
+        else:
+            relation_type = "Unknown"
         return f"{relation_type} relation: {self.to_person} and {self.from_person}"


### PR DESCRIPTION
## Summary
- Fixes `AttributeError` crash when `PersonRelation.type` is `None` (e.g., when adding a Person via the admin popup)
- The `__str__` method now falls back to `"Unknown"` when no relation type is set