### PR TITLE
feat: Add /health endpoint for status checks

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -11,7 +11,13 @@ from wagtail.documents import urls as wagtaildocs_urls
 from content.views import download_blog_post_markdown
 from locations.views import locations_geojson, map_view
 from mapping_violence.api import person_search
-from mapping_violence.views import crime_detail, crime_export_csv, crime_list, index
+from mapping_violence.views import (
+    crime_detail,
+    crime_export_csv,
+    crime_list,
+    health,
+    index,
+)
 
 urlpatterns = [
     path("", index, name="index"),
@@ -36,6 +42,7 @@ urlpatterns = [
     path("documents/", include(wagtaildocs_urls)),
     path("accounts/", include("django.contrib.auth.urls")),
     path("accounts/profile/", TemplateView.as_view(template_name="profile.html")),
+    path("health/", health, name="health"),
     path("schema-viewer/", include("schema_viewer.urls")),
     # Wagtail pages - must be last to act as catch-all
     path("", include(wagtail_urls)),

--- a/mapping_violence/views.py
+++ b/mapping_violence/views.py
@@ -1,7 +1,7 @@
 import csv
 
 from django.db.models import Q
-from django.http import StreamingHttpResponse
+from django.http import JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404, render
 from django_ratelimit.decorators import ratelimit
 from django_tables2 import RequestConfig
@@ -175,3 +175,7 @@ def crime_export_csv(request):
     )
     response["Content-Disposition"] = 'attachment; filename="mapping_violence_data.csv"'
     return response
+
+
+def health(request):
+    return JsonResponse({"status": "ok", "code": 200})


### PR DESCRIPTION
## Summary
- Adds a `/health/` endpoint that returns `{"status": "ok", "code": 200}`
- Matches the pattern used in [Religious Ecologies](https://religiousecologies.org/health/)
- Useful for uptime monitoring and deployment health checks

Closes #78